### PR TITLE
Fixed warnings reported when using -pedantic with gcc 4.2.1

### DIFF
--- a/mach_override.c
+++ b/mach_override.c
@@ -42,7 +42,7 @@ long kIslandTemplate[] = {
 
 #define kOriginalInstructionsSize 16
 
-char kIslandTemplate[] = {
+unsigned char kIslandTemplate[] = {
 	// kOriginalInstructionsSize nop instructions so that we 
 	// should have enough space to host original instructions 
 	0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 
@@ -59,7 +59,7 @@ char kIslandTemplate[] = {
 
 #define kJumpAddress    kOriginalInstructionsSize + 6
 
-char kIslandTemplate[] = {
+unsigned char kIslandTemplate[] = {
 	// kOriginalInstructionsSize nop instructions so that we 
 	// should have enough space to host original instructions 
 	0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 0x90, 


### PR DESCRIPTION
Compiling mach_override.c with gcc 4.2.1 via

  gcc -Wall -pedantic -std=c99 -c mach_override.c

would yield a lot of warnings saying 'warning: overflow in implicit
constant conversion' in the opcode arrays. The reason was that 'char'
is a signed type with this compiler, so 0x90 (as well as 0xFF) were
too large, causing an overflow.

We don't really care whether it's signed or unsigned, but in order
to silence warnings in -pedantic builds just use 'unsigned char' to
be explicit.
