### PR TITLE
Replay

### DIFF
--- a/mach_override.c
+++ b/mach_override.c
@@ -100,7 +100,7 @@ typedef	struct	{
 #pragma mark	-
 #pragma mark	(Funky Protos)
 
-	mach_error_t
+static mach_error_t
 allocateBranchIsland(
 		BranchIsland	**island,
 		void *originalFunctionAddress);
@@ -368,7 +368,7 @@ mach_override_ptr(
 
 	***************************************************************************/
 
-	mach_error_t
+static mach_error_t
 allocateBranchIsland(
 		BranchIsland	**island,
 		void *originalFunctionAddress)

--- a/mach_override.c
+++ b/mach_override.c
@@ -431,18 +431,9 @@ freeBranchIsland(
 {
 	assert( island );
 	assert( (*(long*)&island->instructions[0]) == kIslandTemplate[0] );
-	
-	mach_error_t	err = err_none;
-	
-
-	if( !err ) {
-		assert( sizeof( BranchIsland ) <= kPageSize );
-		err = vm_deallocate(
-				    mach_task_self(),
-				    (vm_address_t) island, kPageSize );
-	}
-	
-	return err;
+	assert( sizeof( BranchIsland ) <= kPageSize );
+	return vm_deallocate( mach_task_self(), (vm_address_t) island,
+			      kPageSize );
 }
 
 /*******************************************************************************

--- a/mach_override.c
+++ b/mach_override.c
@@ -376,43 +376,41 @@ allocateBranchIsland(
 	assert( island );
 	
 	mach_error_t	err = err_none;
-	
-	if( !err ) {
-		assert( sizeof( BranchIsland ) <= kPageSize );
+
+	assert( sizeof( BranchIsland ) <= kPageSize );
 #if defined(__ppc__) || defined(__POWERPC__)
-		vm_address_t first = 0xfeffffff;
-		vm_address_t last = 0xfe000000 + kPageSize;
+	vm_address_t first = 0xfeffffff;
+	vm_address_t last = 0xfe000000 + kPageSize;
 #elif defined(__x86_64__)
-		vm_address_t first = ((uint64_t)originalFunctionAddress & ~(uint64_t)(((uint64_t)1 << 31) - 1)) | ((uint64_t)1 << 31); // start in the middle of the page?
-		vm_address_t last = 0x0;
+	vm_address_t first = ((uint64_t)originalFunctionAddress & ~(uint64_t)(((uint64_t)1 << 31) - 1)) | ((uint64_t)1 << 31); // start in the middle of the page?
+	vm_address_t last = 0x0;
 #else
-		vm_address_t first = 0xffc00000;
-		vm_address_t last = 0xfffe0000;
+	vm_address_t first = 0xffc00000;
+	vm_address_t last = 0xfffe0000;
 #endif
 
-		vm_address_t page = first;
-		int allocated = 0;
-		vm_map_t task_self = mach_task_self();
+	vm_address_t page = first;
+	int allocated = 0;
+	vm_map_t task_self = mach_task_self();
 			
-		while( !err && !allocated && page != last ) {
+	while( !err && !allocated && page != last ) {
 
-			err = vm_allocate( task_self, &page, kPageSize, 0 );
-			if( err == err_none )
-				allocated = 1;
-			else if( err == KERN_NO_SPACE ) {
+		err = vm_allocate( task_self, &page, kPageSize, 0 );
+		if( err == err_none )
+			allocated = 1;
+		else if( err == KERN_NO_SPACE ) {
 #if defined(__x86_64__)
-				page -= kPageSize;
+			page -= kPageSize;
 #else
-				page += kPageSize;
+			page += kPageSize;
 #endif
-				err = err_none;
-			}
+			err = err_none;
 		}
-		if( allocated )
-			*island = (BranchIsland*) page;
-		else if( !allocated && !err )
-			err = KERN_NO_SPACE;
 	}
+	if( allocated )
+		*island = (BranchIsland*) page;
+	else if( !allocated && !err )
+		err = KERN_NO_SPACE;
 
 	return err;
 }

--- a/mach_override.c
+++ b/mach_override.c
@@ -375,8 +375,6 @@ allocateBranchIsland(
 {
 	assert( island );
 	
-	mach_error_t	err = err_none;
-
 	assert( sizeof( BranchIsland ) <= kPageSize );
 #if defined(__ppc__) || defined(__POWERPC__)
 	vm_address_t first = 0xfeffffff;
@@ -390,29 +388,25 @@ allocateBranchIsland(
 #endif
 
 	vm_address_t page = first;
-	int allocated = 0;
 	vm_map_t task_self = mach_task_self();
-			
-	while( !err && !allocated && page != last ) {
 
-		err = vm_allocate( task_self, &page, kPageSize, 0 );
-		if( err == err_none )
-			allocated = 1;
-		else if( err == KERN_NO_SPACE ) {
+	while( page != last ) {
+		mach_error_t err = vm_allocate( task_self, &page, kPageSize, 0 );
+		if( err == err_none ) {
+			*island = (BranchIsland*) page;
+			return err_none;
+                }
+		if( err != KERN_NO_SPACE )
+			return err;
 #if defined(__x86_64__)
-			page -= kPageSize;
+		page -= kPageSize;
 #else
-			page += kPageSize;
+		page += kPageSize;
 #endif
-			err = err_none;
-		}
+		err = err_none;
 	}
-	if( allocated )
-		*island = (BranchIsland*) page;
-	else if( !allocated && !err )
-		err = KERN_NO_SPACE;
 
-	return err;
+	return KERN_NO_SPACE;
 }
 
 /*******************************************************************************

--- a/mach_override.c
+++ b/mach_override.c
@@ -21,6 +21,7 @@
 #pragma mark	-
 #pragma mark	(Constants)
 
+#define kPageSize 4096
 #if defined(__ppc__) || defined(__POWERPC__)
 
 long kIslandTemplate[] = {
@@ -160,12 +161,10 @@ fixupInstructions(
 #if defined(__i386__) || defined(__x86_64__)
 mach_error_t makeIslandExecutable(void *address) {
 	mach_error_t err = err_none;
-    vm_size_t pageSize;
-    host_page_size( mach_host_self(), &pageSize );
-    uintptr_t page = (uintptr_t)address & ~(uintptr_t)(pageSize-1);
+    uintptr_t page = (uintptr_t)address & ~(uintptr_t)(kPageSize-1);
     int e = err_none;
-    e |= mprotect((void *)page, pageSize, PROT_EXEC | PROT_READ | PROT_WRITE);
-    e |= msync((void *)page, pageSize, MS_INVALIDATE );
+    e |= mprotect((void *)page, kPageSize, PROT_EXEC | PROT_READ | PROT_WRITE);
+    e |= msync((void *)page, kPageSize, MS_INVALIDATE );
     if (e) {
         err = err_cannot_override;
     }
@@ -388,13 +387,11 @@ allocateBranchIsland(
 	mach_error_t	err = err_none;
 	
 	if( allocateHigh ) {
-		vm_size_t pageSize;
-		err = host_page_size( mach_host_self(), &pageSize );
 		if( !err ) {
-			assert( sizeof( BranchIsland ) <= pageSize );
+			assert( sizeof( BranchIsland ) <= kPageSize );
 #if defined(__ppc__) || defined(__POWERPC__)
 			vm_address_t first = 0xfeffffff;
-			vm_address_t last = 0xfe000000 + pageSize;
+			vm_address_t last = 0xfe000000 + kPageSize;
 #elif defined(__x86_64__)
 			vm_address_t first = ((uint64_t)originalFunctionAddress & ~(uint64_t)(((uint64_t)1 << 31) - 1)) | ((uint64_t)1 << 31); // start in the middle of the page?
 			vm_address_t last = 0x0;
@@ -409,14 +406,14 @@ allocateBranchIsland(
 			
 			while( !err && !allocated && page != last ) {
 
-				err = vm_allocate( task_self, &page, pageSize, 0 );
+				err = vm_allocate( task_self, &page, kPageSize, 0 );
 				if( err == err_none )
 					allocated = 1;
 				else if( err == KERN_NO_SPACE ) {
 #if defined(__x86_64__)
-					page -= pageSize;
+					page -= kPageSize;
 #else
-					page += pageSize;
+					page += kPageSize;
 #endif
 					err = err_none;
 				}
@@ -458,13 +455,11 @@ freeBranchIsland(
 	mach_error_t	err = err_none;
 	
 	if( island->allocatedHigh ) {
-		vm_size_t pageSize;
-		err = host_page_size( mach_host_self(), &pageSize );
 		if( !err ) {
-			assert( sizeof( BranchIsland ) <= pageSize );
+			assert( sizeof( BranchIsland ) <= kPageSize );
 			err = vm_deallocate(
 					mach_task_self(),
-					(vm_address_t) island, pageSize );
+					(vm_address_t) island, kPageSize );
 		}
 	} else {
 		free( island );

--- a/mach_override.c
+++ b/mach_override.c
@@ -80,9 +80,6 @@ char kIslandTemplate[] = {
 
 #endif
 
-#define	kAllocateHigh		1
-#define	kAllocateNormal		0
-
 /**************************
 *	
 *	Data Types
@@ -93,7 +90,6 @@ char kIslandTemplate[] = {
 
 typedef	struct	{
 	char	instructions[sizeof(kIslandTemplate)];
-	int		allocatedHigh;
 }	BranchIsland;
 
 /**************************
@@ -107,7 +103,6 @@ typedef	struct	{
 	mach_error_t
 allocateBranchIsland(
 		BranchIsland	**island,
-		int				allocateHigh,
 		void *originalFunctionAddress);
 
 	mach_error_t
@@ -242,7 +237,7 @@ mach_override_ptr(
 	//	Allocate and target the escape island to the overriding function.
 	BranchIsland	*escapeIsland = NULL;
 	if( !err )	
-		err = allocateBranchIsland( &escapeIsland, kAllocateHigh, originalFunctionAddress );
+		err = allocateBranchIsland( &escapeIsland, originalFunctionAddress );
 		if (err) fprintf(stderr, "err = %x %s:%d\n", err, __FILE__, __LINE__);
 
 	
@@ -284,7 +279,7 @@ mach_override_ptr(
 	//  technically our original function.
 	BranchIsland	*reentryIsland = NULL;
 	if( !err && originalFunctionReentryIsland ) {
-		err = allocateBranchIsland( &reentryIsland, kAllocateHigh, escapeIsland);
+		err = allocateBranchIsland( &reentryIsland, escapeIsland);
 		if( !err )
 			*originalFunctionReentryIsland = reentryIsland;
 	}
@@ -369,9 +364,6 @@ mach_override_ptr(
 	Implementation: Allocates memory for a branch island.
 	
 	@param	island			<-	The allocated island.
-	@param	allocateHigh	->	Whether to allocate the island at the end of the
-								address space (for use with the branch absolute
-								instruction).
 	@result					<-	mach_error_t
 
 	***************************************************************************/
@@ -379,60 +371,49 @@ mach_override_ptr(
 	mach_error_t
 allocateBranchIsland(
 		BranchIsland	**island,
-		int				allocateHigh,
 		void *originalFunctionAddress)
 {
 	assert( island );
 	
 	mach_error_t	err = err_none;
 	
-	if( allocateHigh ) {
-		if( !err ) {
-			assert( sizeof( BranchIsland ) <= kPageSize );
+	if( !err ) {
+		assert( sizeof( BranchIsland ) <= kPageSize );
 #if defined(__ppc__) || defined(__POWERPC__)
-			vm_address_t first = 0xfeffffff;
-			vm_address_t last = 0xfe000000 + kPageSize;
+		vm_address_t first = 0xfeffffff;
+		vm_address_t last = 0xfe000000 + kPageSize;
 #elif defined(__x86_64__)
-			vm_address_t first = ((uint64_t)originalFunctionAddress & ~(uint64_t)(((uint64_t)1 << 31) - 1)) | ((uint64_t)1 << 31); // start in the middle of the page?
-			vm_address_t last = 0x0;
+		vm_address_t first = ((uint64_t)originalFunctionAddress & ~(uint64_t)(((uint64_t)1 << 31) - 1)) | ((uint64_t)1 << 31); // start in the middle of the page?
+		vm_address_t last = 0x0;
 #else
-			vm_address_t first = 0xffc00000;
-			vm_address_t last = 0xfffe0000;
+		vm_address_t first = 0xffc00000;
+		vm_address_t last = 0xfffe0000;
 #endif
 
-			vm_address_t page = first;
-			int allocated = 0;
-			vm_map_t task_self = mach_task_self();
+		vm_address_t page = first;
+		int allocated = 0;
+		vm_map_t task_self = mach_task_self();
 			
-			while( !err && !allocated && page != last ) {
+		while( !err && !allocated && page != last ) {
 
-				err = vm_allocate( task_self, &page, kPageSize, 0 );
-				if( err == err_none )
-					allocated = 1;
-				else if( err == KERN_NO_SPACE ) {
+			err = vm_allocate( task_self, &page, kPageSize, 0 );
+			if( err == err_none )
+				allocated = 1;
+			else if( err == KERN_NO_SPACE ) {
 #if defined(__x86_64__)
-					page -= kPageSize;
+				page -= kPageSize;
 #else
-					page += kPageSize;
+				page += kPageSize;
 #endif
-					err = err_none;
-				}
+				err = err_none;
 			}
-			if( allocated )
-				*island = (BranchIsland*) page;
-			else if( !allocated && !err )
-				err = KERN_NO_SPACE;
 		}
-	} else {
-		void *block = malloc( sizeof( BranchIsland ) );
-		if( block )
-			*island = block;
-		else
+		if( allocated )
+			*island = (BranchIsland*) page;
+		else if( !allocated && !err )
 			err = KERN_NO_SPACE;
 	}
-	if( !err )
-		(**island).allocatedHigh = allocateHigh;
-	
+
 	return err;
 }
 
@@ -450,19 +431,15 @@ freeBranchIsland(
 {
 	assert( island );
 	assert( (*(long*)&island->instructions[0]) == kIslandTemplate[0] );
-	assert( island->allocatedHigh );
 	
 	mach_error_t	err = err_none;
 	
-	if( island->allocatedHigh ) {
-		if( !err ) {
-			assert( sizeof( BranchIsland ) <= kPageSize );
-			err = vm_deallocate(
-					mach_task_self(),
-					(vm_address_t) island, kPageSize );
-		}
-	} else {
-		free( island );
+
+	if( !err ) {
+		assert( sizeof( BranchIsland ) <= kPageSize );
+		err = vm_deallocate(
+				    mach_task_self(),
+				    (vm_address_t) island, kPageSize );
 	}
 	
 	return err;


### PR DESCRIPTION
Other than the last two patches this is just a replay of the previous pull request that was reverted because of the problems in chrome.

The difference in the last two patches is that we now try walk the memory regions in both directions. Before I had tested only patching library functions, and they go in the end of the address space, which is why a backward walk worked for me.

The tests still passed for me on OS X 10.8.
