### PR TITLE
Add support for relative call instructions in reentry island

### DIFF
--- a/mach_override.c
+++ b/mach_override.c
@@ -641,7 +641,7 @@ fixupInstructions(
 	int	index;
 	for (index = 0;index < instructionCount;index += 1)
 	{
-        uint8_t opcode = *(uint8_t*)instructionsToFix;
+		uint8_t opcode = *(uint8_t*)instructionsToFix;
 		if ((opcode == 0xE9) || (opcode == 0xE8)) // 32-bit jump/call relative
 		{
 			uint32_t offset = (uintptr_t)originalFunction - (uintptr_t)escapeIsland;

--- a/mach_override.c
+++ b/mach_override.c
@@ -641,7 +641,8 @@ fixupInstructions(
 	int	index;
 	for (index = 0;index < instructionCount;index += 1)
 	{
-		if (*(uint8_t*)instructionsToFix == 0xE9) // 32-bit jump relative
+        uint8_t opcode = *(uint8_t*)instructionsToFix;
+		if ((opcode == 0xE9) || (opcode == 0xE8)) // 32-bit jump/call relative
 		{
 			uint32_t offset = (uintptr_t)originalFunction - (uintptr_t)escapeIsland;
 			uint32_t *jumpOffsetPtr = (uint32_t*)((uintptr_t)instructionsToFix + 1);


### PR DESCRIPTION
Currently, the `fixupInstructions` function only relocates relative jump offsets and nothing else. This causes segfaults when calling the reentry islands of functions that contain relative _call_ instructions in their first 5 bytes.

If you're looking for a concrete example, check out the `PKGSpaceGet*` functions in CoreGraphics (they're only used in WindowServer and aren't exported, FYI):
![pkgspacegetname](https://cloud.githubusercontent.com/assets/4801634/2985735/4c7a1dbc-dc3e-11e3-8536-10e7343eb712.png)

---

There are other types of instructions with relative offsets that also cause segfaults in reentry islands*, but I honestly don't feel adept enough at the moment to write a general solution, so I left it at that.

\* Compiling `test_mach_override.cp` with clang yields crashes, for instance. I'm assuming that happens because the nops in `localFunction()` get optimized away and the relative load instruction for `__FUNCTION__` is copied as-is.
